### PR TITLE
Add table classes for academic domain entities

### DIFF
--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/AssessmentDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/AssessmentDto.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class AssessmentDto {
+    public Long id;
+    public String subjectId;
+    public String teacherId;
+    public String academicYearId;
+    public String title;
+    public String description;
+    public Long assessmentTypeId;
+    public Double maxScore;
+    public LocalDate date;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/AttendanceDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/AttendanceDto.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.academic.application.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class AttendanceDto {
+    public Long id;
+    public String subjectId;
+    public Long studentId;
+    public LocalDate date;
+    public String status;
+    public String observation;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/BehaviorReportDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/BehaviorReportDto.java
@@ -1,0 +1,15 @@
+package com.andersonsinaluisa.academicapi.academic.application.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BehaviorReportDto {
+    public Long id;
+    public Long studentId;
+    public Long termId;
+    public Double score;
+    public String observations;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/EnrollmentDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/EnrollmentDto.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.academic.application.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+public class EnrollmentDto {
+    public Long id;
+    public Long studentId;
+    public String courseId;
+    public String academicYearId;
+    public LocalDate enrollmentDate;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/GradingSystemDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/GradingSystemDto.java
@@ -1,0 +1,15 @@
+package com.andersonsinaluisa.academicapi.academic.application.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GradingSystemDto {
+    public Long id;
+    public String name;
+    public String description;
+    public Integer numberOfTerms;
+    public Double passingScore;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/MeetingDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/MeetingDto.java
@@ -1,0 +1,19 @@
+package com.andersonsinaluisa.academicapi.academic.application.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class MeetingDto {
+    public Long id;
+    public String courseId;
+    public String academicYearId;
+    public LocalDateTime meetingDate;
+    public String location;
+    public String meetingType;
+    public Long createdBy;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/ReportCardDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/dtos/ReportCardDto.java
@@ -1,0 +1,15 @@
+package com.andersonsinaluisa.academicapi.academic.application.dtos;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ReportCardDto {
+    public Long id;
+    public String academicYearId;
+    public Long studentId;
+    public Double averageScore;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/AssessmentMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/AssessmentMapper.java
@@ -1,0 +1,35 @@
+package com.andersonsinaluisa.academicapi.academic.application.mappers;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.AssessmentDto;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.assessment.Assessment;
+
+public class AssessmentMapper {
+    public static Assessment fromDtoToDomain(AssessmentDto dto) {
+        return Assessment.builder()
+                .id(dto.id)
+                .subjectId(dto.subjectId)
+                .teacherId(dto.teacherId)
+                .academicYearId(dto.academicYearId)
+                .title(dto.title)
+                .description(dto.description)
+                .assessmentTypeId(dto.assessmentTypeId)
+                .maxScore(dto.maxScore)
+                .date(dto.date)
+                .build();
+    }
+
+    public static AssessmentDto fromDomainToDto(Assessment assessment) {
+        return AssessmentDto.builder()
+                .id(assessment.id)
+                .subjectId(assessment.subjectId)
+                .teacherId(assessment.teacherId)
+                .academicYearId(assessment.academicYearId)
+                .title(assessment.title)
+                .description(assessment.description)
+                .assessmentTypeId(assessment.assessmentTypeId)
+                .maxScore(assessment.maxScore)
+                .date(assessment.date)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/AttendanceMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/AttendanceMapper.java
@@ -1,0 +1,29 @@
+package com.andersonsinaluisa.academicapi.academic.application.mappers;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.AttendanceDto;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.attendance.Attendance;
+
+public class AttendanceMapper {
+    public static Attendance fromDtoToDomain(AttendanceDto dto) {
+        return Attendance.builder()
+                .id(dto.id)
+                .subjectId(dto.subjectId)
+                .studentId(dto.studentId)
+                .date(dto.date)
+                .status(dto.status)
+                .observation(dto.observation)
+                .build();
+    }
+
+    public static AttendanceDto fromDomainToDto(Attendance attendance) {
+        return AttendanceDto.builder()
+                .id(attendance.id)
+                .subjectId(attendance.subjectId)
+                .studentId(attendance.studentId)
+                .date(attendance.date)
+                .status(attendance.status)
+                .observation(attendance.observation)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/BehaviorReportMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/BehaviorReportMapper.java
@@ -1,0 +1,27 @@
+package com.andersonsinaluisa.academicapi.academic.application.mappers;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.BehaviorReportDto;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.behavior.BehaviorReport;
+
+public class BehaviorReportMapper {
+    public static BehaviorReport fromDtoToDomain(BehaviorReportDto dto) {
+        return BehaviorReport.builder()
+                .id(dto.id)
+                .studentId(dto.studentId)
+                .termId(dto.termId)
+                .score(dto.score)
+                .observations(dto.observations)
+                .build();
+    }
+
+    public static BehaviorReportDto fromDomainToDto(BehaviorReport behavior) {
+        return BehaviorReportDto.builder()
+                .id(behavior.id)
+                .studentId(behavior.studentId)
+                .termId(behavior.termId)
+                .score(behavior.score)
+                .observations(behavior.observations)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/EnrollmentMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/EnrollmentMapper.java
@@ -1,0 +1,29 @@
+package com.andersonsinaluisa.academicapi.academic.application.mappers;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.EnrollmentDto;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.enrollment.Enrollment;
+
+public class EnrollmentMapper {
+    public static Enrollment fromDtoToDomain(EnrollmentDto dto) {
+        return Enrollment.builder()
+                .id(dto.id)
+                .studentId(dto.studentId)
+                .courseId(dto.courseId)
+                .academicYearId(dto.academicYearId)
+                .enrollmentDate(dto.enrollmentDate)
+                .status(dto.status)
+                .build();
+    }
+
+    public static EnrollmentDto fromDomainToDto(Enrollment enrollment) {
+        return EnrollmentDto.builder()
+                .id(enrollment.id)
+                .studentId(enrollment.studentId)
+                .courseId(enrollment.courseId)
+                .academicYearId(enrollment.academicYearId)
+                .enrollmentDate(enrollment.enrollmentDate)
+                .status(enrollment.status)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/GradingSystemMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/GradingSystemMapper.java
@@ -1,0 +1,27 @@
+package com.andersonsinaluisa.academicapi.academic.application.mappers;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.GradingSystemDto;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.grading.GradingSystem;
+
+public class GradingSystemMapper {
+    public static GradingSystem fromDtoToDomain(GradingSystemDto dto) {
+        return GradingSystem.builder()
+                .id(dto.id)
+                .name(dto.name)
+                .description(dto.description)
+                .numberOfTerms(dto.numberOfTerms)
+                .passingScore(dto.passingScore)
+                .build();
+    }
+
+    public static GradingSystemDto fromDomainToDto(GradingSystem gradingSystem) {
+        return GradingSystemDto.builder()
+                .id(gradingSystem.id)
+                .name(gradingSystem.name)
+                .description(gradingSystem.description)
+                .numberOfTerms(gradingSystem.numberOfTerms)
+                .passingScore(gradingSystem.passingScore)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/MeetingMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/MeetingMapper.java
@@ -1,0 +1,32 @@
+package com.andersonsinaluisa.academicapi.academic.application.mappers;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.MeetingDto;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.meeting.Meeting;
+import com.andersonsinaluisa.academicapi.academic.domain.valueObjects.MeetingDate;
+
+public class MeetingMapper {
+    public static Meeting fromDtoToDomain(MeetingDto dto) {
+        return Meeting.builder()
+                .id(dto.id)
+                .courseId(dto.courseId)
+                .academicYearId(dto.academicYearId)
+                .meetingDate(new MeetingDate(dto.meetingDate))
+                .location(dto.location)
+                .meetingType(dto.meetingType)
+                .createdBy(dto.createdBy)
+                .build();
+    }
+
+    public static MeetingDto fromDomainToDto(Meeting meeting) {
+        return MeetingDto.builder()
+                .id(meeting.id)
+                .courseId(meeting.courseId)
+                .academicYearId(meeting.academicYearId)
+                .meetingDate(meeting.meetingDate.getValue())
+                .location(meeting.location)
+                .meetingType(meeting.meetingType)
+                .createdBy(meeting.createdBy)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/ReportCardMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/mappers/ReportCardMapper.java
@@ -1,0 +1,28 @@
+package com.andersonsinaluisa.academicapi.academic.application.mappers;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.ReportCardDto;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.reports.ReportCard;
+import com.andersonsinaluisa.academicapi.academic.domain.valueObjects.Score;
+
+public class ReportCardMapper {
+    public static ReportCard fromDtoToDomain(ReportCardDto dto) {
+        return ReportCard.builder()
+                .id(dto.id)
+                .academicYearId(dto.academicYearId)
+                .studentId(dto.studentId)
+                .averageScore(new Score(dto.averageScore))
+                .status(dto.status)
+                .build();
+    }
+
+    public static ReportCardDto fromDomainToDto(ReportCard reportCard) {
+        return ReportCardDto.builder()
+                .id(reportCard.id)
+                .academicYearId(reportCard.academicYearId)
+                .studentId(reportCard.studentId)
+                .averageScore(reportCard.averageScore.getValue())
+                .status(reportCard.status)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/assessment/RegisterAssessmentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/assessment/RegisterAssessmentUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.assessment;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.AssessmentDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.AssessmentMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AssessmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterAssessmentUseCase {
+
+    private final AssessmentRepository repository;
+
+    public Mono<AssessmentDto> execute(AssessmentDto dto) {
+        return repository.save(AssessmentMapper.fromDtoToDomain(dto))
+                .map(AssessmentMapper::fromDomainToDto);
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/attendance/RecordAttendanceUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/attendance/RecordAttendanceUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.attendance;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.AttendanceDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.AttendanceMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class RecordAttendanceUseCase {
+
+    private final AttendanceRepository repository;
+
+    public Mono<AttendanceDto> execute(AttendanceDto dto) {
+        return repository.save(AttendanceMapper.fromDtoToDomain(dto))
+                .map(AttendanceMapper::fromDomainToDto);
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/behavior/LogBehaviorReportUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/behavior/LogBehaviorReportUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.behavior;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.BehaviorReportDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.BehaviorReportMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.BehaviorReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class LogBehaviorReportUseCase {
+
+    private final BehaviorReportRepository repository;
+
+    public Mono<BehaviorReportDto> execute(BehaviorReportDto dto) {
+        return repository.save(BehaviorReportMapper.fromDtoToDomain(dto))
+                .map(BehaviorReportMapper::fromDomainToDto);
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/enrollment/CreateEnrollmentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/enrollment/CreateEnrollmentUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.enrollment;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.EnrollmentDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.EnrollmentMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.EnrollmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class CreateEnrollmentUseCase {
+
+    private final EnrollmentRepository repository;
+
+    public Mono<EnrollmentDto> execute(EnrollmentDto dto) {
+        return repository.save(EnrollmentMapper.fromDtoToDomain(dto))
+                .map(EnrollmentMapper::fromDomainToDto);
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/grading/CalculateFinalGradesUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/grading/CalculateFinalGradesUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.grading;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.ReportCardDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.ReportCardMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.ReportCardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class CalculateFinalGradesUseCase {
+
+    private final ReportCardRepository repository;
+
+    public Mono<ReportCardDto> execute(ReportCardDto dto) {
+        return repository.save(ReportCardMapper.fromDtoToDomain(dto))
+                .map(ReportCardMapper::fromDomainToDto);
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/meeting/CreateMeetingRecordUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/meeting/CreateMeetingRecordUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.meeting;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.MeetingDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.MeetingMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.MeetingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class CreateMeetingRecordUseCase {
+
+    private final MeetingRepository repository;
+
+    public Mono<MeetingDto> execute(MeetingDto dto) {
+        return repository.save(MeetingMapper.fromDtoToDomain(dto))
+                .map(MeetingMapper::fromDomainToDto);
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/reports/GenerateReportCardUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/reports/GenerateReportCardUseCase.java
@@ -1,0 +1,20 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.reports;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.ReportCardDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.ReportCardMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.ReportCardRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class GenerateReportCardUseCase {
+
+    private final ReportCardRepository repository;
+
+    public Flux<ReportCardDto> execute() {
+        return repository.findAll().map(ReportCardMapper::fromDomainToDto);
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/assessment/Assessment.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/assessment/Assessment.java
@@ -1,0 +1,23 @@
+package com.andersonsinaluisa.academicapi.academic.domain.entities.assessment;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Assessment {
+    public Long id;
+    public String subjectId;
+    public String teacherId;
+    public String academicYearId;
+    public String title;
+    public String description;
+    public Long assessmentTypeId;
+    public Double maxScore;
+    public LocalDate date;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/attendance/Attendance.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/attendance/Attendance.java
@@ -1,0 +1,20 @@
+package com.andersonsinaluisa.academicapi.academic.domain.entities.attendance;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Attendance {
+    public Long id;
+    public String subjectId;
+    public Long studentId;
+    public LocalDate date;
+    public String status;
+    public String observation;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/behavior/BehaviorReport.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/behavior/BehaviorReport.java
@@ -1,0 +1,17 @@
+package com.andersonsinaluisa.academicapi.academic.domain.entities.behavior;
+
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BehaviorReport {
+    public Long id;
+    public Long studentId;
+    public Long termId;
+    public Double score;
+    public String observations;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/enrollment/Enrollment.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/enrollment/Enrollment.java
@@ -1,0 +1,20 @@
+package com.andersonsinaluisa.academicapi.academic.domain.entities.enrollment;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Enrollment {
+    public Long id;
+    public Long studentId;
+    public String courseId;
+    public String academicYearId;
+    public LocalDate enrollmentDate;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/grading/GradingSystem.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/grading/GradingSystem.java
@@ -1,0 +1,17 @@
+package com.andersonsinaluisa.academicapi.academic.domain.entities.grading;
+
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradingSystem {
+    public Long id;
+    public String name;
+    public String description;
+    public Integer numberOfTerms;
+    public Double passingScore;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/meeting/Meeting.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/meeting/Meeting.java
@@ -1,0 +1,20 @@
+package com.andersonsinaluisa.academicapi.academic.domain.entities.meeting;
+
+import com.andersonsinaluisa.academicapi.academic.domain.valueObjects.MeetingDate;
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Meeting {
+    public Long id;
+    public String courseId;
+    public String academicYearId;
+    public MeetingDate meetingDate;
+    public String location;
+    public String meetingType;
+    public Long createdBy;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/reports/ReportCard.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/entities/reports/ReportCard.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.academic.domain.entities.reports;
+
+import com.andersonsinaluisa.academicapi.academic.domain.valueObjects.Score;
+import lombok.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportCard {
+    public Long id;
+    public String academicYearId;
+    public Long studentId;
+    public Score averageScore;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/AssessmentRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/AssessmentRepository.java
@@ -1,0 +1,11 @@
+package com.andersonsinaluisa.academicapi.academic.domain.repository;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.assessment.Assessment;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface AssessmentRepository {
+    Mono<Assessment> save(Assessment assessment);
+    Flux<Assessment> findAll();
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/AttendanceRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/AttendanceRepository.java
@@ -1,0 +1,11 @@
+package com.andersonsinaluisa.academicapi.academic.domain.repository;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.attendance.Attendance;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface AttendanceRepository {
+    Mono<Attendance> save(Attendance attendance);
+    Flux<Attendance> findAll();
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/BehaviorReportRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/BehaviorReportRepository.java
@@ -1,0 +1,11 @@
+package com.andersonsinaluisa.academicapi.academic.domain.repository;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.behavior.BehaviorReport;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface BehaviorReportRepository {
+    Mono<BehaviorReport> save(BehaviorReport report);
+    Flux<BehaviorReport> findAll();
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/EnrollmentRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/EnrollmentRepository.java
@@ -1,0 +1,11 @@
+package com.andersonsinaluisa.academicapi.academic.domain.repository;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.enrollment.Enrollment;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface EnrollmentRepository {
+    Mono<Enrollment> save(Enrollment enrollment);
+    Flux<Enrollment> findAll();
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/GradingSystemRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/GradingSystemRepository.java
@@ -1,0 +1,11 @@
+package com.andersonsinaluisa.academicapi.academic.domain.repository;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.grading.GradingSystem;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface GradingSystemRepository {
+    Mono<GradingSystem> save(GradingSystem gradingSystem);
+    Flux<GradingSystem> findAll();
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/MeetingRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/MeetingRepository.java
@@ -1,0 +1,11 @@
+package com.andersonsinaluisa.academicapi.academic.domain.repository;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.meeting.Meeting;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface MeetingRepository {
+    Mono<Meeting> save(Meeting meeting);
+    Flux<Meeting> findAll();
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/ReportCardRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/ReportCardRepository.java
@@ -1,0 +1,11 @@
+package com.andersonsinaluisa.academicapi.academic.domain.repository;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.reports.ReportCard;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface ReportCardRepository {
+    Mono<ReportCard> save(ReportCard reportCard);
+    Flux<ReportCard> findAll();
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/valueObjects/MeetingDate.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/valueObjects/MeetingDate.java
@@ -1,0 +1,19 @@
+package com.andersonsinaluisa.academicapi.academic.domain.valueObjects;
+
+import java.time.LocalDateTime;
+
+public class MeetingDate {
+    private final LocalDateTime value;
+
+    public MeetingDate(LocalDateTime value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Meeting date cannot be null");
+        }
+        this.value = value;
+    }
+
+    public LocalDateTime getValue() {
+        return value;
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/valueObjects/Score.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/valueObjects/Score.java
@@ -1,0 +1,17 @@
+package com.andersonsinaluisa.academicapi.academic.domain.valueObjects;
+
+public class Score {
+    private final Double value;
+
+    public Score(Double value) {
+        if (value == null || value < 0) {
+            throw new IllegalArgumentException("Score must be positive");
+        }
+        this.value = value;
+    }
+
+    public Double getValue() {
+        return value;
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/valueObjects/TermPeriod.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/valueObjects/TermPeriod.java
@@ -1,0 +1,25 @@
+package com.andersonsinaluisa.academicapi.academic.domain.valueObjects;
+
+import java.time.LocalDate;
+
+public class TermPeriod {
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+
+    public TermPeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null || endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("Invalid term period");
+        }
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/AssessmentRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/AssessmentRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.assessment.Assessment;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AssessmentRepository;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.assessment.AssessmentTable;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa.AssessmentPgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class AssessmentRepositoryImpl implements AssessmentRepository {
+
+    private final AssessmentPgRepository repository;
+
+    @Override
+    public Mono<Assessment> save(Assessment assessment) {
+        return repository.save(toTable(assessment)).map(this::toDomain);
+    }
+
+    @Override
+    public Flux<Assessment> findAll() {
+        return repository.findAll().map(this::toDomain);
+    }
+
+    private AssessmentTable toTable(Assessment a) {
+        return AssessmentTable.builder()
+                .id(a.id)
+                .subjectId(a.subjectId)
+                .teacherId(a.teacherId)
+                .academicYearId(a.academicYearId)
+                .title(a.title)
+                .description(a.description)
+                .assessmentTypeId(a.assessmentTypeId)
+                .maxScore(a.maxScore)
+                .date(a.date)
+                .build();
+    }
+
+    private Assessment toDomain(AssessmentTable t) {
+        return Assessment.builder()
+                .id(t.id)
+                .subjectId(t.subjectId)
+                .teacherId(t.teacherId)
+                .academicYearId(t.academicYearId)
+                .title(t.title)
+                .description(t.description)
+                .assessmentTypeId(t.assessmentTypeId)
+                .maxScore(t.maxScore)
+                .date(t.date)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/AttendanceRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/AttendanceRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.attendance.Attendance;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AttendanceRepository;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.attendance.AttendanceTable;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa.AttendancePgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceRepositoryImpl implements AttendanceRepository {
+
+    private final AttendancePgRepository repository;
+
+    @Override
+    public Mono<Attendance> save(Attendance attendance) {
+        return repository.save(toTable(attendance)).map(this::toDomain);
+    }
+
+    @Override
+    public Flux<Attendance> findAll() {
+        return repository.findAll().map(this::toDomain);
+    }
+
+    private AttendanceTable toTable(Attendance a) {
+        return AttendanceTable.builder()
+                .id(a.id)
+                .subjectId(a.subjectId)
+                .studentId(a.studentId)
+                .date(a.date)
+                .status(a.status)
+                .observation(a.observation)
+                .build();
+    }
+
+    private Attendance toDomain(AttendanceTable t) {
+        return Attendance.builder()
+                .id(t.id)
+                .subjectId(t.subjectId)
+                .studentId(t.studentId)
+                .date(t.date)
+                .status(t.status)
+                .observation(t.observation)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/BehaviorReportRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/BehaviorReportRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.behavior.BehaviorReport;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.BehaviorReportRepository;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.behavior.BehaviorReportTable;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa.BehaviorReportPgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class BehaviorReportRepositoryImpl implements BehaviorReportRepository {
+
+    private final BehaviorReportPgRepository repository;
+
+    @Override
+    public Mono<BehaviorReport> save(BehaviorReport report) {
+        return repository.save(toTable(report)).map(this::toDomain);
+    }
+
+    @Override
+    public Flux<BehaviorReport> findAll() {
+        return repository.findAll().map(this::toDomain);
+    }
+
+    private BehaviorReportTable toTable(BehaviorReport b) {
+        return BehaviorReportTable.builder()
+                .id(b.id)
+                .studentId(b.studentId)
+                .termId(b.termId)
+                .score(b.score)
+                .observations(b.observations)
+                .build();
+    }
+
+    private BehaviorReport toDomain(BehaviorReportTable t) {
+        return BehaviorReport.builder()
+                .id(t.id)
+                .studentId(t.studentId)
+                .termId(t.termId)
+                .score(t.score)
+                .observations(t.observations)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/EnrollmentRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.enrollment.Enrollment;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.EnrollmentRepository;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment.EnrollmentTable;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa.EnrollmentPgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentRepositoryImpl implements EnrollmentRepository {
+
+    private final EnrollmentPgRepository repository;
+
+    @Override
+    public Mono<Enrollment> save(Enrollment enrollment) {
+        return repository.save(toTable(enrollment)).map(this::toDomain);
+    }
+
+    @Override
+    public Flux<Enrollment> findAll() {
+        return repository.findAll().map(this::toDomain);
+    }
+
+    private EnrollmentTable toTable(Enrollment e) {
+        return EnrollmentTable.builder()
+                .id(e.id)
+                .studentId(e.studentId)
+                .courseId(e.courseId)
+                .academicYearId(e.academicYearId)
+                .enrollmentDate(e.enrollmentDate)
+                .status(e.status)
+                .build();
+    }
+
+    private Enrollment toDomain(EnrollmentTable t) {
+        return Enrollment.builder()
+                .id(t.id)
+                .studentId(t.studentId)
+                .courseId(t.courseId)
+                .academicYearId(t.academicYearId)
+                .enrollmentDate(t.enrollmentDate)
+                .status(t.status)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/GradingSystemRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/GradingSystemRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.grading.GradingSystem;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.GradingSystemRepository;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.grading.GradingSystemTable;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa.GradingSystemPgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class GradingSystemRepositoryImpl implements GradingSystemRepository {
+
+    private final GradingSystemPgRepository repository;
+
+    @Override
+    public Mono<GradingSystem> save(GradingSystem gradingSystem) {
+        return repository.save(toTable(gradingSystem)).map(this::toDomain);
+    }
+
+    @Override
+    public Flux<GradingSystem> findAll() {
+        return repository.findAll().map(this::toDomain);
+    }
+
+    private GradingSystemTable toTable(GradingSystem g) {
+        return GradingSystemTable.builder()
+                .id(g.id)
+                .name(g.name)
+                .description(g.description)
+                .numberOfTerms(g.numberOfTerms)
+                .passingScore(g.passingScore)
+                .build();
+    }
+
+    private GradingSystem toDomain(GradingSystemTable t) {
+        return GradingSystem.builder()
+                .id(t.id)
+                .name(t.name)
+                .description(t.description)
+                .numberOfTerms(t.numberOfTerms)
+                .passingScore(t.passingScore)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/MeetingRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/MeetingRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.meeting.Meeting;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.MeetingRepository;
+import com.andersonsinaluisa.academicapi.academic.domain.valueObjects.MeetingDate;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.meeting.MeetingTable;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa.MeetingPgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingRepositoryImpl implements MeetingRepository {
+
+    private final MeetingPgRepository repository;
+
+    @Override
+    public Mono<Meeting> save(Meeting meeting) {
+        return repository.save(toTable(meeting)).map(this::toDomain);
+    }
+
+    @Override
+    public Flux<Meeting> findAll() {
+        return repository.findAll().map(this::toDomain);
+    }
+
+    private MeetingTable toTable(Meeting m) {
+        return MeetingTable.builder()
+                .id(m.id)
+                .courseId(m.courseId)
+                .academicYearId(m.academicYearId)
+                .meetingDate(m.meetingDate.getValue().toLocalDate())
+                .location(m.location)
+                .meetingType(m.meetingType)
+                .createdBy(m.createdBy)
+                .build();
+    }
+
+    private Meeting toDomain(MeetingTable t) {
+        return Meeting.builder()
+                .id(t.id)
+                .courseId(t.courseId)
+                .academicYearId(t.academicYearId)
+                .meetingDate(new MeetingDate(t.meetingDate.atStartOfDay()))
+                .location(t.location)
+                .meetingType(t.meetingType)
+                .createdBy(t.createdBy)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/ReportCardRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/ReportCardRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.reports.ReportCard;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.ReportCardRepository;
+import com.andersonsinaluisa.academicapi.academic.domain.valueObjects.Score;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.reports.ReportCardTable;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa.ReportCardPgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class ReportCardRepositoryImpl implements ReportCardRepository {
+
+    private final ReportCardPgRepository repository;
+
+    @Override
+    public Mono<ReportCard> save(ReportCard reportCard) {
+        return repository.save(toTable(reportCard)).map(this::toDomain);
+    }
+
+    @Override
+    public Flux<ReportCard> findAll() {
+        return repository.findAll().map(this::toDomain);
+    }
+
+    private ReportCardTable toTable(ReportCard r) {
+        return ReportCardTable.builder()
+                .id(r.id)
+                .academicYearId(r.academicYearId)
+                .studentId(r.studentId)
+                .averageScore(r.averageScore.getValue())
+                .status(r.status)
+                .build();
+    }
+
+    private ReportCard toDomain(ReportCardTable t) {
+        return ReportCard.builder()
+                .id(t.id)
+                .academicYearId(t.academicYearId)
+                .studentId(t.studentId)
+                .averageScore(new Score(t.averageScore))
+                .status(t.status)
+                .build();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/assessment/AssessmentTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/assessment/AssessmentTable.java
@@ -1,0 +1,27 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.assessment;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDate;
+
+@Table(name="assessment")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class AssessmentTable {
+    @Id
+    public Long id;
+    public String subjectId;
+    public Long teacherId;
+    public String academicYearId;
+    public String title;
+    public String description;
+    public Long assessmentTypeId;
+    public Double maxScore;
+    public LocalDate date;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/assessment/AssessmentTypeTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/assessment/AssessmentTypeTable.java
@@ -1,0 +1,19 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.assessment;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="assessment_type")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class AssessmentTypeTable {
+    @Id
+    public Long id;
+    public String name;
+    public Double weight;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/attendance/AttendanceTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/attendance/AttendanceTable.java
@@ -1,0 +1,24 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.attendance;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDate;
+
+@Table(name="attendance")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class AttendanceTable {
+    @Id
+    public Long id;
+    public String subjectId;
+    public Long studentId;
+    public LocalDate date;
+    public String status;
+    public String observation;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/behavior/BehaviorReportTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/behavior/BehaviorReportTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.behavior;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="behavior_report")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class BehaviorReportTable {
+    @Id
+    public Long id;
+    public Long studentId;
+    public Long termId;
+    public Double score;
+    public String observations;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/behavior/DisciplinaryActionTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/behavior/DisciplinaryActionTable.java
@@ -1,0 +1,23 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.behavior;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDate;
+
+@Table(name="disciplinary_action")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class DisciplinaryActionTable {
+    @Id
+    public Long id;
+    public Long studentId;
+    public LocalDate date;
+    public String action;
+    public String description;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/enrollment/EnrollmentTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/enrollment/EnrollmentTable.java
@@ -1,0 +1,24 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDate;
+
+@Table(name="enrollment")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class EnrollmentTable {
+    @Id
+    public Long id;
+    public Long studentId;
+    public String courseId;
+    public String academicYearId;
+    public LocalDate enrollmentDate;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/enrollment/SubjectEnrollmentTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/enrollment/SubjectEnrollmentTable.java
@@ -1,0 +1,19 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="subject_enrollment")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class SubjectEnrollmentTable {
+    @Id
+    public Long id;
+    public Long enrollmentId;
+    public String subjectId;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/enrollment/TeacherAssignmentTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/enrollment/TeacherAssignmentTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="teacher_assignment")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class TeacherAssignmentTable {
+    @Id
+    public Long id;
+    public Long teacherId;
+    public String subjectId;
+    public String courseId;
+    public String academicYearId;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/grading/AcademicYearGradingTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/grading/AcademicYearGradingTable.java
@@ -1,0 +1,19 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.grading;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="academic_year_grading")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class AcademicYearGradingTable {
+    @Id
+    public Long id;
+    public String academicYearId;
+    public Long gradingSystemId;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/grading/GradeTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/grading/GradeTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.grading;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="grade")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class GradeTable {
+    @Id
+    public Long id;
+    public Long assessmentId;
+    public Long studentId;
+    public Double score;
+    public String feedback;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/grading/GradingSystemTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/grading/GradingSystemTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.grading;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="grading_system")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class GradingSystemTable {
+    @Id
+    public Long id;
+    public String name;
+    public String description;
+    public Integer numberOfTerms;
+    public Double passingScore;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/grading/GradingTermTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/grading/GradingTermTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.grading;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="grading_term")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class GradingTermTable {
+    @Id
+    public Long id;
+    public Long gradingSystemId;
+    public String name;
+    public Integer order;
+    public Double weight;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/meeting/MeetingAttachmentTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/meeting/MeetingAttachmentTable.java
@@ -1,0 +1,20 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.meeting;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="meeting_attachment")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class MeetingAttachmentTable {
+    @Id
+    public Long id;
+    public Long meetingId;
+    public String fileUrl;
+    public String description;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/meeting/MeetingAttendanceTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/meeting/MeetingAttendanceTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.meeting;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="meeting_attendance")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class MeetingAttendanceTable {
+    @Id
+    public Long id;
+    public Long meetingId;
+    public Long personId;
+    public String role;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/meeting/MeetingMinutesTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/meeting/MeetingMinutesTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.meeting;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="meeting_minutes")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class MeetingMinutesTable {
+    @Id
+    public Long id;
+    public Long meetingId;
+    public String summary;
+    public String decisions;
+    public String nextSteps;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/meeting/MeetingTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/meeting/MeetingTable.java
@@ -1,0 +1,25 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.meeting;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDate;
+
+@Table(name="meeting")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class MeetingTable {
+    @Id
+    public Long id;
+    public String courseId;
+    public String academicYearId;
+    public LocalDate meetingDate;
+    public String location;
+    public String meetingType;
+    public Long createdBy;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/AuditLogTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/AuditLogTable.java
@@ -1,0 +1,26 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.reports;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table(name="audit_log")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class AuditLogTable {
+    @Id
+    public Long id;
+    public String entity;
+    public Long entityId;
+    public String action;
+    public String changedBy;
+    public LocalDateTime changedAt;
+    public String oldValue;
+    public String newValue;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/FinalGradeTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/FinalGradeTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.reports;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="final_grade")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class FinalGradeTable {
+    @Id
+    public Long id;
+    public String academicYearId;
+    public Long studentId;
+    public Double averageScore;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/ReportCardTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/ReportCardTable.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.reports;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="report_card")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ReportCardTable {
+    @Id
+    public Long id;
+    public String academicYearId;
+    public Long studentId;
+    public Double averageScore;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/TermGradeTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/TermGradeTable.java
@@ -1,0 +1,22 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.reports;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table(name="term_grade")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class TermGradeTable {
+    @Id
+    public Long id;
+    public Long termId;
+    public String subjectId;
+    public Long studentId;
+    public Double averageScore;
+    public String status;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/TermTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/reports/TermTable.java
@@ -1,0 +1,23 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.reports;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDate;
+
+@Table(name="term")
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class TermTable {
+    @Id
+    public Long id;
+    public String academicYearId;
+    public String name;
+    public LocalDate startDate;
+    public LocalDate endDate;
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/custom/EnrollmentCustomRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/custom/EnrollmentCustomRepository.java
@@ -1,0 +1,30 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.custom;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment.EnrollmentTable;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+@Repository
+public class EnrollmentCustomRepository {
+    private final DatabaseClient client;
+
+    public EnrollmentCustomRepository(DatabaseClient client) {
+        this.client = client;
+    }
+
+    public Flux<EnrollmentTable> findByStatus(String status) {
+        return client.sql("SELECT * FROM enrollment WHERE status = :status")
+                .bind("status", status)
+                .map((row, meta) -> EnrollmentTable.builder()
+                        .id(row.get("id", Long.class))
+                        .studentId(row.get("student_id", Long.class))
+                        .courseId(row.get("course_id", String.class))
+                        .academicYearId(row.get("academic_year_id", String.class))
+                        .enrollmentDate(row.get("enrollment_date", java.time.LocalDate.class))
+                        .status(row.get("status", String.class))
+                        .build())
+                .all();
+    }
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/AssessmentPgRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/AssessmentPgRepository.java
@@ -1,0 +1,10 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.assessment.AssessmentTable;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AssessmentPgRepository extends ReactiveCrudRepository<AssessmentTable, Long> {
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/AttendancePgRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/AttendancePgRepository.java
@@ -1,0 +1,10 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.attendance.AttendanceTable;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AttendancePgRepository extends ReactiveCrudRepository<AttendanceTable, Long> {
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/BehaviorReportPgRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/BehaviorReportPgRepository.java
@@ -1,0 +1,10 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.behavior.BehaviorReportTable;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BehaviorReportPgRepository extends ReactiveCrudRepository<BehaviorReportTable, Long> {
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/EnrollmentPgRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/EnrollmentPgRepository.java
@@ -1,0 +1,10 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment.EnrollmentTable;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EnrollmentPgRepository extends ReactiveCrudRepository<EnrollmentTable, Long> {
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/GradingSystemPgRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/GradingSystemPgRepository.java
@@ -1,0 +1,10 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.grading.GradingSystemTable;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GradingSystemPgRepository extends ReactiveCrudRepository<GradingSystemTable, Long> {
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/MeetingPgRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/MeetingPgRepository.java
@@ -1,0 +1,10 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.meeting.MeetingTable;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MeetingPgRepository extends ReactiveCrudRepository<MeetingTable, Long> {
+}
+

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/ReportCardPgRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/ReportCardPgRepository.java
@@ -1,0 +1,10 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.reports.ReportCardTable;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportCardPgRepository extends ReactiveCrudRepository<ReportCardTable, Long> {
+}
+


### PR DESCRIPTION
## Summary
- add enrollment and teacher assignment table definitions
- add assessment and grading table definitions
- add reporting, attendance, behavior, and audit log tables
- add meeting log and grading system table definitions
- implement academic domain entities, value objects, repositories, DTOs, mappers, and use cases

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: spring-boot-starter-parent 3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_6893890569988330bfa582ce1c8afc92