### PR TITLE
Add CRUD operations for academic and person entities

### DIFF
--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/AssessmentController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/AssessmentController.java
@@ -2,11 +2,12 @@ package com.andersonsinaluisa.academicapi.academic.api.controllers;
 
 import com.andersonsinaluisa.academicapi.academic.application.dtos.AssessmentDto;
 import com.andersonsinaluisa.academicapi.academic.application.usecases.assessment.RegisterAssessmentUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.assessment.ListAssessmentUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.assessment.UpdateAssessmentUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.assessment.DeleteAssessmentUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -15,9 +16,27 @@ import reactor.core.publisher.Mono;
 public class AssessmentController {
 
     private final RegisterAssessmentUseCase registerAssessmentUseCase;
+    private final ListAssessmentUseCase listAssessmentUseCase;
+    private final UpdateAssessmentUseCase updateAssessmentUseCase;
+    private final DeleteAssessmentUseCase deleteAssessmentUseCase;
 
     @PostMapping
     public Mono<AssessmentDto> register(@RequestBody AssessmentDto dto) {
         return registerAssessmentUseCase.execute(dto);
+    }
+
+    @GetMapping
+    public Flux<AssessmentDto> list() {
+        return listAssessmentUseCase.execute();
+    }
+
+    @PutMapping("/{id}")
+    public Mono<AssessmentDto> update(@PathVariable Long id, @RequestBody AssessmentDto dto) {
+        return updateAssessmentUseCase.execute(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public Mono<Void> delete(@PathVariable Long id) {
+        return deleteAssessmentUseCase.execute(id);
     }
 }

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/AttendanceController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/AttendanceController.java
@@ -2,11 +2,12 @@ package com.andersonsinaluisa.academicapi.academic.api.controllers;
 
 import com.andersonsinaluisa.academicapi.academic.application.dtos.AttendanceDto;
 import com.andersonsinaluisa.academicapi.academic.application.usecases.attendance.RecordAttendanceUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.attendance.ListAttendanceUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.attendance.UpdateAttendanceUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.attendance.DeleteAttendanceUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -15,9 +16,27 @@ import reactor.core.publisher.Mono;
 public class AttendanceController {
 
     private final RecordAttendanceUseCase recordAttendanceUseCase;
+    private final ListAttendanceUseCase listAttendanceUseCase;
+    private final UpdateAttendanceUseCase updateAttendanceUseCase;
+    private final DeleteAttendanceUseCase deleteAttendanceUseCase;
 
     @PostMapping
     public Mono<AttendanceDto> record(@RequestBody AttendanceDto dto) {
         return recordAttendanceUseCase.execute(dto);
+    }
+
+    @GetMapping
+    public Flux<AttendanceDto> list() {
+        return listAttendanceUseCase.execute();
+    }
+
+    @PutMapping("/{id}")
+    public Mono<AttendanceDto> update(@PathVariable Long id, @RequestBody AttendanceDto dto) {
+        return updateAttendanceUseCase.execute(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public Mono<Void> delete(@PathVariable Long id) {
+        return deleteAttendanceUseCase.execute(id);
     }
 }

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/BehaviorReportController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/BehaviorReportController.java
@@ -2,11 +2,12 @@ package com.andersonsinaluisa.academicapi.academic.api.controllers;
 
 import com.andersonsinaluisa.academicapi.academic.application.dtos.BehaviorReportDto;
 import com.andersonsinaluisa.academicapi.academic.application.usecases.behavior.LogBehaviorReportUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.behavior.ListBehaviorReportUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.behavior.UpdateBehaviorReportUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.behavior.DeleteBehaviorReportUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -15,9 +16,27 @@ import reactor.core.publisher.Mono;
 public class BehaviorReportController {
 
     private final LogBehaviorReportUseCase logBehaviorReportUseCase;
+    private final ListBehaviorReportUseCase listBehaviorReportUseCase;
+    private final UpdateBehaviorReportUseCase updateBehaviorReportUseCase;
+    private final DeleteBehaviorReportUseCase deleteBehaviorReportUseCase;
 
     @PostMapping
     public Mono<BehaviorReportDto> log(@RequestBody BehaviorReportDto dto) {
         return logBehaviorReportUseCase.execute(dto);
+    }
+
+    @GetMapping
+    public Flux<BehaviorReportDto> list() {
+        return listBehaviorReportUseCase.execute();
+    }
+
+    @PutMapping("/{id}")
+    public Mono<BehaviorReportDto> update(@PathVariable Long id, @RequestBody BehaviorReportDto dto) {
+        return updateBehaviorReportUseCase.execute(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public Mono<Void> delete(@PathVariable Long id) {
+        return deleteBehaviorReportUseCase.execute(id);
     }
 }

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/EnrollmentController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/EnrollmentController.java
@@ -2,11 +2,12 @@ package com.andersonsinaluisa.academicapi.academic.api.controllers;
 
 import com.andersonsinaluisa.academicapi.academic.application.dtos.EnrollmentDto;
 import com.andersonsinaluisa.academicapi.academic.application.usecases.enrollment.CreateEnrollmentUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.enrollment.ListEnrollmentUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.enrollment.UpdateEnrollmentUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.enrollment.DeleteEnrollmentUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -15,9 +16,27 @@ import reactor.core.publisher.Mono;
 public class EnrollmentController {
 
     private final CreateEnrollmentUseCase createEnrollmentUseCase;
+    private final ListEnrollmentUseCase listEnrollmentUseCase;
+    private final UpdateEnrollmentUseCase updateEnrollmentUseCase;
+    private final DeleteEnrollmentUseCase deleteEnrollmentUseCase;
 
     @PostMapping
     public Mono<EnrollmentDto> create(@RequestBody EnrollmentDto dto) {
         return createEnrollmentUseCase.execute(dto);
+    }
+
+    @GetMapping
+    public Flux<EnrollmentDto> list() {
+        return listEnrollmentUseCase.execute();
+    }
+
+    @PutMapping("/{id}")
+    public Mono<EnrollmentDto> update(@PathVariable Long id, @RequestBody EnrollmentDto dto) {
+        return updateEnrollmentUseCase.execute(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public Mono<Void> delete(@PathVariable Long id) {
+        return deleteEnrollmentUseCase.execute(id);
     }
 }

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/MeetingController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/api/controllers/MeetingController.java
@@ -2,11 +2,12 @@ package com.andersonsinaluisa.academicapi.academic.api.controllers;
 
 import com.andersonsinaluisa.academicapi.academic.application.dtos.MeetingDto;
 import com.andersonsinaluisa.academicapi.academic.application.usecases.meeting.CreateMeetingRecordUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.meeting.ListMeetingUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.meeting.UpdateMeetingUseCase;
+import com.andersonsinaluisa.academicapi.academic.application.usecases.meeting.DeleteMeetingUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RestController
@@ -15,9 +16,27 @@ import reactor.core.publisher.Mono;
 public class MeetingController {
 
     private final CreateMeetingRecordUseCase createMeetingRecordUseCase;
+    private final ListMeetingUseCase listMeetingUseCase;
+    private final UpdateMeetingUseCase updateMeetingUseCase;
+    private final DeleteMeetingUseCase deleteMeetingUseCase;
 
     @PostMapping
     public Mono<MeetingDto> create(@RequestBody MeetingDto dto) {
         return createMeetingRecordUseCase.execute(dto);
+    }
+
+    @GetMapping
+    public Flux<MeetingDto> list() {
+        return listMeetingUseCase.execute();
+    }
+
+    @PutMapping("/{id}")
+    public Mono<MeetingDto> update(@PathVariable Long id, @RequestBody MeetingDto dto) {
+        return updateMeetingUseCase.execute(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public Mono<Void> delete(@PathVariable Long id) {
+        return deleteMeetingUseCase.execute(id);
     }
 }

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/assessment/DeleteAssessmentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/assessment/DeleteAssessmentUseCase.java
@@ -1,0 +1,16 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.assessment;
+
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AssessmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteAssessmentUseCase {
+    private final AssessmentRepository repository;
+
+    public Mono<Void> execute(Long id) {
+        return repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/assessment/ListAssessmentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/assessment/ListAssessmentUseCase.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.assessment;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.AssessmentDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.AssessmentMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AssessmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class ListAssessmentUseCase {
+    private final AssessmentRepository repository;
+
+    public Flux<AssessmentDto> execute() {
+        return repository.findAll().map(AssessmentMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/assessment/UpdateAssessmentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/assessment/UpdateAssessmentUseCase.java
@@ -1,0 +1,22 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.assessment;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.AssessmentDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.AssessmentMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.assessment.Assessment;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AssessmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateAssessmentUseCase {
+    private final AssessmentRepository repository;
+
+    public Mono<AssessmentDto> execute(Long id, AssessmentDto dto) {
+        Assessment assessment = AssessmentMapper.fromDtoToDomain(dto);
+        assessment.id = id;
+        return repository.save(assessment)
+                .map(AssessmentMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/attendance/DeleteAttendanceUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/attendance/DeleteAttendanceUseCase.java
@@ -1,0 +1,16 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.attendance;
+
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteAttendanceUseCase {
+    private final AttendanceRepository repository;
+
+    public Mono<Void> execute(Long id) {
+        return repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/attendance/ListAttendanceUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/attendance/ListAttendanceUseCase.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.attendance;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.AttendanceDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.AttendanceMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class ListAttendanceUseCase {
+    private final AttendanceRepository repository;
+
+    public Flux<AttendanceDto> execute() {
+        return repository.findAll().map(AttendanceMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/attendance/UpdateAttendanceUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/attendance/UpdateAttendanceUseCase.java
@@ -1,0 +1,22 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.attendance;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.AttendanceDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.AttendanceMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.attendance.Attendance;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateAttendanceUseCase {
+    private final AttendanceRepository repository;
+
+    public Mono<AttendanceDto> execute(Long id, AttendanceDto dto) {
+        Attendance attendance = AttendanceMapper.fromDtoToDomain(dto);
+        attendance.id = id;
+        return repository.save(attendance)
+                .map(AttendanceMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/behavior/DeleteBehaviorReportUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/behavior/DeleteBehaviorReportUseCase.java
@@ -1,0 +1,16 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.behavior;
+
+import com.andersonsinaluisa.academicapi.academic.domain.repository.BehaviorReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteBehaviorReportUseCase {
+    private final BehaviorReportRepository repository;
+
+    public Mono<Void> execute(Long id) {
+        return repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/behavior/ListBehaviorReportUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/behavior/ListBehaviorReportUseCase.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.behavior;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.BehaviorReportDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.BehaviorReportMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.BehaviorReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class ListBehaviorReportUseCase {
+    private final BehaviorReportRepository repository;
+
+    public Flux<BehaviorReportDto> execute() {
+        return repository.findAll().map(BehaviorReportMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/behavior/UpdateBehaviorReportUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/behavior/UpdateBehaviorReportUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.behavior;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.BehaviorReportDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.BehaviorReportMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.behavior.BehaviorReport;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.BehaviorReportRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateBehaviorReportUseCase {
+    private final BehaviorReportRepository repository;
+
+    public Mono<BehaviorReportDto> execute(Long id, BehaviorReportDto dto) {
+        BehaviorReport report = BehaviorReportMapper.fromDtoToDomain(dto);
+        report.id = id;
+        return repository.save(report).map(BehaviorReportMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/enrollment/DeleteEnrollmentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/enrollment/DeleteEnrollmentUseCase.java
@@ -1,0 +1,16 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.enrollment;
+
+import com.andersonsinaluisa.academicapi.academic.domain.repository.EnrollmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteEnrollmentUseCase {
+    private final EnrollmentRepository repository;
+
+    public Mono<Void> execute(Long id) {
+        return repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/enrollment/ListEnrollmentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/enrollment/ListEnrollmentUseCase.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.enrollment;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.EnrollmentDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.EnrollmentMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.EnrollmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class ListEnrollmentUseCase {
+    private final EnrollmentRepository repository;
+
+    public Flux<EnrollmentDto> execute() {
+        return repository.findAll().map(EnrollmentMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/enrollment/UpdateEnrollmentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/enrollment/UpdateEnrollmentUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.enrollment;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.EnrollmentDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.EnrollmentMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.enrollment.Enrollment;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.EnrollmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateEnrollmentUseCase {
+    private final EnrollmentRepository repository;
+
+    public Mono<EnrollmentDto> execute(Long id, EnrollmentDto dto) {
+        Enrollment enrollment = EnrollmentMapper.fromDtoToDomain(dto);
+        enrollment.id = id;
+        return repository.save(enrollment).map(EnrollmentMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/meeting/DeleteMeetingUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/meeting/DeleteMeetingUseCase.java
@@ -1,0 +1,16 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.meeting;
+
+import com.andersonsinaluisa.academicapi.academic.domain.repository.MeetingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteMeetingUseCase {
+    private final MeetingRepository repository;
+
+    public Mono<Void> execute(Long id) {
+        return repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/meeting/ListMeetingUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/meeting/ListMeetingUseCase.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.meeting;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.MeetingDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.MeetingMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.MeetingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+@RequiredArgsConstructor
+public class ListMeetingUseCase {
+    private final MeetingRepository repository;
+
+    public Flux<MeetingDto> execute() {
+        return repository.findAll().map(MeetingMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/meeting/UpdateMeetingUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/application/usecases/meeting/UpdateMeetingUseCase.java
@@ -1,0 +1,21 @@
+package com.andersonsinaluisa.academicapi.academic.application.usecases.meeting;
+
+import com.andersonsinaluisa.academicapi.academic.application.dtos.MeetingDto;
+import com.andersonsinaluisa.academicapi.academic.application.mappers.MeetingMapper;
+import com.andersonsinaluisa.academicapi.academic.domain.entities.meeting.Meeting;
+import com.andersonsinaluisa.academicapi.academic.domain.repository.MeetingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateMeetingUseCase {
+    private final MeetingRepository repository;
+
+    public Mono<MeetingDto> execute(Long id, MeetingDto dto) {
+        Meeting meeting = MeetingMapper.fromDtoToDomain(dto);
+        meeting.id = id;
+        return repository.save(meeting).map(MeetingMapper::fromDomainToDto);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/AssessmentRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/AssessmentRepository.java
@@ -7,5 +7,7 @@ import reactor.core.publisher.Mono;
 public interface AssessmentRepository {
     Mono<Assessment> save(Assessment assessment);
     Flux<Assessment> findAll();
+    Mono<Assessment> findById(Long id);
+    Mono<Void> deleteById(Long id);
 }
 

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/AttendanceRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/AttendanceRepository.java
@@ -7,5 +7,7 @@ import reactor.core.publisher.Mono;
 public interface AttendanceRepository {
     Mono<Attendance> save(Attendance attendance);
     Flux<Attendance> findAll();
+    Mono<Attendance> findById(Long id);
+    Mono<Void> deleteById(Long id);
 }
 

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/BehaviorReportRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/BehaviorReportRepository.java
@@ -7,5 +7,7 @@ import reactor.core.publisher.Mono;
 public interface BehaviorReportRepository {
     Mono<BehaviorReport> save(BehaviorReport report);
     Flux<BehaviorReport> findAll();
+    Mono<BehaviorReport> findById(Long id);
+    Mono<Void> deleteById(Long id);
 }
 

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/EnrollmentRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/EnrollmentRepository.java
@@ -7,5 +7,7 @@ import reactor.core.publisher.Mono;
 public interface EnrollmentRepository {
     Mono<Enrollment> save(Enrollment enrollment);
     Flux<Enrollment> findAll();
+    Mono<Enrollment> findById(Long id);
+    Mono<Void> deleteById(Long id);
 }
 

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/MeetingRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/domain/repository/MeetingRepository.java
@@ -7,5 +7,7 @@ import reactor.core.publisher.Mono;
 public interface MeetingRepository {
     Mono<Meeting> save(Meeting meeting);
     Flux<Meeting> findAll();
+    Mono<Meeting> findById(Long id);
+    Mono<Void> deleteById(Long id);
 }
 

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/AssessmentRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/AssessmentRepositoryImpl.java
@@ -25,6 +25,16 @@ public class AssessmentRepositoryImpl implements AssessmentRepository {
         return repository.findAll().map(this::toDomain);
     }
 
+    @Override
+    public Mono<Assessment> findById(Long id) {
+        return repository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    public Mono<Void> deleteById(Long id) {
+        return repository.deleteById(id);
+    }
+
     private AssessmentTable toTable(Assessment a) {
         return AssessmentTable.builder()
                 .id(a.id)

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/AttendanceRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/AttendanceRepositoryImpl.java
@@ -25,6 +25,16 @@ public class AttendanceRepositoryImpl implements AttendanceRepository {
         return repository.findAll().map(this::toDomain);
     }
 
+    @Override
+    public Mono<Attendance> findById(Long id) {
+        return repository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    public Mono<Void> deleteById(Long id) {
+        return repository.deleteById(id);
+    }
+
     private AttendanceTable toTable(Attendance a) {
         return AttendanceTable.builder()
                 .id(a.id)

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/BehaviorReportRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/BehaviorReportRepositoryImpl.java
@@ -25,6 +25,16 @@ public class BehaviorReportRepositoryImpl implements BehaviorReportRepository {
         return repository.findAll().map(this::toDomain);
     }
 
+    @Override
+    public Mono<BehaviorReport> findById(Long id) {
+        return repository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    public Mono<Void> deleteById(Long id) {
+        return repository.deleteById(id);
+    }
+
     private BehaviorReportTable toTable(BehaviorReport b) {
         return BehaviorReportTable.builder()
                 .id(b.id)

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/EnrollmentRepositoryImpl.java
@@ -25,6 +25,16 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepository {
         return repository.findAll().map(this::toDomain);
     }
 
+    @Override
+    public Mono<Enrollment> findById(Long id) {
+        return repository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    public Mono<Void> deleteById(Long id) {
+        return repository.deleteById(id);
+    }
+
     private EnrollmentTable toTable(Enrollment e) {
         return EnrollmentTable.builder()
                 .id(e.id)

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/MeetingRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/MeetingRepositoryImpl.java
@@ -26,6 +26,16 @@ public class MeetingRepositoryImpl implements MeetingRepository {
         return repository.findAll().map(this::toDomain);
     }
 
+    @Override
+    public Mono<Meeting> findById(Long id) {
+        return repository.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    public Mono<Void> deleteById(Long id) {
+        return repository.deleteById(id);
+    }
+
     private MeetingTable toTable(Meeting m) {
         return MeetingTable.builder()
                 .id(m.id)

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/api/RepresentativeController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/api/RepresentativeController.java
@@ -4,26 +4,56 @@ package com.andersonsinaluisa.academicapi.persons.api;
 import com.andersonsinaluisa.academicapi.persons.application.dtos.RepresentativeInputDto;
 import com.andersonsinaluisa.academicapi.persons.application.dtos.RepresentativeOutputDto;
 import com.andersonsinaluisa.academicapi.persons.application.mappers.RepresentativeMapper;
-import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
-import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.andersonsinaluisa.academicapi.persons.application.usecases.representative.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/representative")
 public class RepresentativeController {
 
-    private RepresentativeRepository representativeRepository;
+    private CreateRepresentativeUseCase createRepresentativeUseCase;
+    private ListRepresentativeUseCase listRepresentativeUseCase;
+    private GetByIdRepresentativeUseCase getByIdRepresentativeUseCase;
+    private UpdateRepresentativeUseCase updateRepresentativeUseCase;
+    private DeleteRepresentativeUseCase deleteRepresentativeUseCase;
     @PostMapping
     public Mono<RepresentativeOutputDto> create(
             @RequestBody RepresentativeInputDto representativeInputDto){
-        return representativeRepository
-                .create(
-                        RepresentativeMapper
-                                .fromDtoToDomain(representativeInputDto))
+        return createRepresentativeUseCase
+                .execute(RepresentativeMapper.fromDtoToDomain(representativeInputDto))
                 .map(RepresentativeMapper::fromDomainToDto);
+    }
+
+    @GetMapping
+    public Mono<Page<RepresentativeOutputDto>> list(
+            @RequestParam("page") int page,
+            @RequestParam("limit") int limit
+    ){
+        Pageable pageable = Pageable.ofSize(limit).withPage(page);
+        return listRepresentativeUseCase.execute(pageable)
+                .map(p -> p.map(RepresentativeMapper::fromDomainToDto));
+    }
+
+    @GetMapping("{id}")
+    public Mono<RepresentativeOutputDto> get(@PathVariable Long id){
+        return getByIdRepresentativeUseCase.execute(id)
+                .map(RepresentativeMapper::fromDomainToDto);
+    }
+
+    @PatchMapping("{id}")
+    public Mono<RepresentativeOutputDto> update(@PathVariable Long id,
+                                                @RequestBody RepresentativeInputDto representativeInputDto){
+        Representative representative = RepresentativeMapper.fromDtoToDomain(representativeInputDto);
+        representative.id = id;
+        return updateRepresentativeUseCase.execute(representative)
+                .map(RepresentativeMapper::fromDomainToDto);
+    }
+
+    @DeleteMapping("{id}")
+    public Mono<Void> delete(@PathVariable Long id){
+        return deleteRepresentativeUseCase.execute(id);
     }
 }

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/api/TeacherController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/api/TeacherController.java
@@ -1,0 +1,60 @@
+package com.andersonsinaluisa.academicapi.persons.api;
+
+import com.andersonsinaluisa.academicapi.persons.application.dtos.TeacherInputDto;
+import com.andersonsinaluisa.academicapi.persons.application.dtos.TeacherOutputDto;
+import com.andersonsinaluisa.academicapi.persons.application.mappers.TeacherMapper;
+import com.andersonsinaluisa.academicapi.persons.application.usecases.teacher.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/teachers")
+public class TeacherController {
+
+    private CreateTeacherUseCase createTeacherUseCase;
+    private ListTeacherUseCase listTeacherUseCase;
+    private GetByIdTeacherUseCase getByIdTeacherUseCase;
+    private UpdateTeacherUseCase updateTeacherUseCase;
+    private DeleteTeacherUseCase deleteTeacherUseCase;
+
+    @PostMapping
+    public Mono<TeacherOutputDto> create(@RequestBody TeacherInputDto dto){
+        return createTeacherUseCase.execute(TeacherMapper.fromDtoToDomain(dto))
+                .map(TeacherMapper::fromDomainToDto);
+    }
+
+    @GetMapping
+    public Mono<Page<TeacherOutputDto>> list(
+            @RequestParam("page") int page,
+            @RequestParam("limit") int limit,
+            @RequestParam(value = "firstName", required = false) String firstName,
+            @RequestParam(value = "lastName", required = false) String lastName,
+            @RequestParam(value = "identification", required = false) String identification,
+            @RequestParam(value = "gender", required = false) String gender
+    ){
+        Pageable pageable = Pageable.ofSize(limit).withPage(page);
+        return listTeacherUseCase.execute(pageable, firstName, lastName, identification, gender)
+                .map(p -> p.map(TeacherMapper::fromDomainToDto));
+    }
+
+    @GetMapping("{id}")
+    public Mono<TeacherOutputDto> get(@PathVariable Long id){
+        return getByIdTeacherUseCase.execute(id)
+                .map(TeacherMapper::fromDomainToDto);
+    }
+
+    @PatchMapping("{id}")
+    public Mono<TeacherOutputDto> update(@PathVariable Long id, @RequestBody TeacherInputDto dto){
+        var teacher = TeacherMapper.fromDtoToDomain(dto);
+        teacher.id = id;
+        return updateTeacherUseCase.execute(teacher)
+                .map(TeacherMapper::fromDomainToDto);
+    }
+
+    @DeleteMapping("{id}")
+    public Mono<Void> delete(@PathVariable Long id){
+        return deleteTeacherUseCase.execute(id);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/dtos/TeacherInputDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/dtos/TeacherInputDto.java
@@ -1,0 +1,16 @@
+package com.andersonsinaluisa.academicapi.persons.application.dtos;
+
+import java.time.LocalDate;
+
+public class TeacherInputDto {
+    public String fistName;
+    public String lastName;
+    public String phone;
+    public LocalDate birthDate;
+    public String uuidUser;
+    public String address;
+    public String identification;
+    public String nacionality;
+    public String gender;
+    public String image;
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/dtos/TeacherOutputDto.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/dtos/TeacherOutputDto.java
@@ -1,0 +1,20 @@
+package com.andersonsinaluisa.academicapi.persons.application.dtos;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public class TeacherOutputDto {
+    public Long id;
+    public String fistName;
+    public String lastName;
+    public String phone;
+    public LocalDate birthDate;
+    public String uuidUser;
+    public String address;
+    public String identification;
+    public String nacionality;
+    public String gender;
+    public String image;
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/mappers/TeacherMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/mappers/TeacherMapper.java
@@ -1,0 +1,41 @@
+package com.andersonsinaluisa.academicapi.persons.application.mappers;
+
+import com.andersonsinaluisa.academicapi.persons.application.dtos.TeacherInputDto;
+import com.andersonsinaluisa.academicapi.persons.application.dtos.TeacherOutputDto;
+import com.andersonsinaluisa.academicapi.persons.domain.entities.Teacher;
+import com.andersonsinaluisa.academicapi.persons.domain.valueObjects.BirthDate;
+import com.andersonsinaluisa.academicapi.persons.domain.valueObjects.FullName;
+import com.andersonsinaluisa.academicapi.persons.domain.valueObjects.Identification;
+import com.andersonsinaluisa.academicapi.persons.domain.valueObjects.PhoneNumber;
+
+public class TeacherMapper {
+    public static Teacher fromDtoToDomain(TeacherInputDto dto){
+        return Teacher.builder()
+                .address(dto.address)
+                .birthDate(new BirthDate(dto.birthDate))
+                .fullName(new FullName(dto.fistName,dto.lastName))
+                .gender(dto.gender)
+                .identification(new Identification(dto.identification))
+                .image(dto.image)
+                .nacionality(dto.nacionality)
+                .phone(new PhoneNumber(dto.phone))
+                .uuidUser(dto.uuidUser)
+                .build();
+    }
+
+    public static TeacherOutputDto fromDomainToDto(Teacher teacher){
+        return TeacherOutputDto.builder()
+                .id(teacher.id)
+                .address(teacher.address)
+                .birthDate(teacher.birthDate.getValue())
+                .fistName(teacher.fullName.getFirstName())
+                .lastName(teacher.fullName.getLastName())
+                .gender(teacher.gender)
+                .identification(teacher.identification.getValue())
+                .image(teacher.image)
+                .nacionality(teacher.nacionality)
+                .phone(teacher.phone.getValue())
+                .uuidUser(teacher.uuidUser)
+                .build();
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/DeleteRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/DeleteRepresentativeUseCase.java
@@ -1,0 +1,14 @@
+package com.andersonsinaluisa.academicapi.persons.application.usecases.representative;
+
+import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class DeleteRepresentativeUseCase {
+    private RepresentativeRepository representativeRepository;
+
+    public Mono<Void> execute(Long id) {
+        return representativeRepository.delete(id);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/GetByIdRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/GetByIdRepresentativeUseCase.java
@@ -1,0 +1,15 @@
+package com.andersonsinaluisa.academicapi.persons.application.usecases.representative;
+
+import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
+import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class GetByIdRepresentativeUseCase {
+    private RepresentativeRepository representativeRepository;
+
+    public Mono<Representative> execute(Long id) {
+        return representativeRepository.getById(id);
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/ListRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/ListRepresentativeUseCase.java
@@ -1,0 +1,18 @@
+package com.andersonsinaluisa.academicapi.persons.application.usecases.representative;
+
+import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
+import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
+import com.andersonsinaluisa.academicapi.shared.domain.FilterCriteria;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class ListRepresentativeUseCase {
+    private RepresentativeRepository representativeRepository;
+
+    public Mono<Page<Representative>> execute(Pageable pageable) {
+        return representativeRepository.all(pageable, new FilterCriteria());
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/teacher/GetByIdTeacherUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/teacher/GetByIdTeacherUseCase.java
@@ -2,8 +2,10 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.teacher;
 
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Teacher;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.TeacherRepository;
+import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+@Service
 public class GetByIdTeacherUseCase {
 
     private TeacherRepository teacherRepository;

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/domain/repository/RepresentativeRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/domain/repository/RepresentativeRepository.java
@@ -19,5 +19,7 @@ public interface RepresentativeRepository {
 
     Mono<Page<Representative>> all(Pageable pageable, FilterCriteria filterCriteria);
 
+    Mono<Representative> getById(Long id);
+
 
 }

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/infrastructure/RepresentativeRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/infrastructure/RepresentativeRepositoryImpl.java
@@ -56,6 +56,12 @@ public class RepresentativeRepositoryImpl implements RepresentativeRepository {
     }
 
     @Override
+    public Mono<Representative> getById(Long id) {
+        return representativePgRepository.findById(id)
+                .map(RepresentativeTableMapper::fromPersistenceToDomain);
+    }
+
+    @Override
     public Mono<Page<Representative>> all(Pageable pageable,
                                           FilterCriteria filterCriteria) {
         int pageSize = pageable.getPageSize();


### PR DESCRIPTION
## Summary
- implement list/update/delete endpoints for academic modules (assessments, attendance, behavior reports, enrollments, meetings)
- add repository methods and use cases supporting new operations
- introduce teacher DTOs, mapper, controller and expand representative API with full CRUD

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893dc437dfc833091bafd9ebd32d7f6