### PR TITLE
Annotate missing dependencies with @Autowired

### DIFF
--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/api/RepresentativeController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/api/RepresentativeController.java
@@ -6,6 +6,7 @@ import com.andersonsinaluisa.academicapi.persons.application.dtos.Representative
 import com.andersonsinaluisa.academicapi.persons.application.mappers.RepresentativeMapper;
 import com.andersonsinaluisa.academicapi.persons.application.usecases.representative.*;
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
@@ -14,10 +15,15 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/representative")
 public class RepresentativeController {
 
+    @Autowired
     private CreateRepresentativeUseCase createRepresentativeUseCase;
+    @Autowired
     private ListRepresentativeUseCase listRepresentativeUseCase;
+    @Autowired
     private GetByIdRepresentativeUseCase getByIdRepresentativeUseCase;
+    @Autowired
     private UpdateRepresentativeUseCase updateRepresentativeUseCase;
+    @Autowired
     private DeleteRepresentativeUseCase deleteRepresentativeUseCase;
     @PostMapping
     public Mono<RepresentativeOutputDto> create(

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/api/StudentController.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/api/StudentController.java
@@ -3,6 +3,7 @@ package com.andersonsinaluisa.academicapi.persons.api;
 import com.andersonsinaluisa.academicapi.persons.application.dtos.StudentInputDto;
 import com.andersonsinaluisa.academicapi.persons.application.dtos.StudentOutputDto;
 import com.andersonsinaluisa.academicapi.persons.application.mappers.StudentMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import reactor.core.publisher.Mono;
@@ -14,10 +15,15 @@ import com.andersonsinaluisa.academicapi.persons.application.usecases.student.*;
 @RequestMapping("/students")
 public class StudentController {
 
+    @Autowired
     private CreateStudentUseCase createStudentUseCase;
+    @Autowired
     private ListStudentByCourseIdUseCase listStudentByCourseIdUseCase;
+    @Autowired
     private GetByIdStudentUseCase getByIdStudentUseCase;
+    @Autowired
     private UpdateStudentUseCase updateStudentUseCase;
+    @Autowired
     private DeleteStudentUseCase deleteStudentUseCase;
     @PostMapping
     public Mono<StudentOutputDto> create(@RequestBody StudentInputDto dto){

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/AssignRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/AssignRepresentativeUseCase.java
@@ -3,14 +3,15 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.represent
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Student;
 import com.andersonsinaluisa.academicapi.persons.domain.entities.StudentRepresentative;
-import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.StudentRepresentiveRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
 public class AssignRepresentativeUseCase {
 
+    @Autowired
     private StudentRepresentiveRepository representativeRepository;
 
     public Mono<StudentRepresentative> execute(

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/CreateRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/CreateRepresentativeUseCase.java
@@ -2,12 +2,14 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.represent
 
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
 public class CreateRepresentativeUseCase {
 
+    @Autowired
     private RepresentativeRepository representativeRepository;
 
     public Mono<Representative> execute(Representative representative){

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/DeleteRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/DeleteRepresentativeUseCase.java
@@ -1,11 +1,13 @@
 package com.andersonsinaluisa.academicapi.persons.application.usecases.representative;
 
 import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
 public class DeleteRepresentativeUseCase {
+    @Autowired
     private RepresentativeRepository representativeRepository;
 
     public Mono<Void> execute(Long id) {

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/GetByIdRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/GetByIdRepresentativeUseCase.java
@@ -2,11 +2,13 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.represent
 
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
 public class GetByIdRepresentativeUseCase {
+    @Autowired
     private RepresentativeRepository representativeRepository;
 
     public Mono<Representative> execute(Long id) {

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/ListRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/ListRepresentativeUseCase.java
@@ -3,6 +3,7 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.represent
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
 import com.andersonsinaluisa.academicapi.shared.domain.FilterCriteria;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import reactor.core.publisher.Mono;
 
 @Service
 public class ListRepresentativeUseCase {
+    @Autowired
     private RepresentativeRepository representativeRepository;
 
     public Mono<Page<Representative>> execute(Pageable pageable) {

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/UnAssignRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/UnAssignRepresentativeUseCase.java
@@ -3,11 +3,13 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.represent
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Student;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.StudentRepresentiveRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 @Service
 public class UnAssignRepresentativeUseCase {
 
+    @Autowired
     private StudentRepresentiveRepository studentRepresentiveRepository;
     public Mono<Void> execute(Representative representative, Student student){
 

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/UpdateRepresentativeUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/representative/UpdateRepresentativeUseCase.java
@@ -2,12 +2,14 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.represent
 
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Representative;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
 public class UpdateRepresentativeUseCase {
 
+    @Autowired
     private RepresentativeRepository representativeRepository;
     public Mono<Representative> execute(Representative representative){
 

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/CreateStudentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/CreateStudentUseCase.java
@@ -6,6 +6,7 @@ import com.andersonsinaluisa.academicapi.persons.domain.entities.StudentRepresen
 import com.andersonsinaluisa.academicapi.persons.domain.repository.RepresentativeRepository;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.StudentRepository;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.StudentRepresentiveRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -15,9 +16,12 @@ import java.util.List;
 @Service
 public class CreateStudentUseCase {
 
-    public StudentRepository studentRepository;
-    public RepresentativeRepository representativeRepository;
-    public StudentRepresentiveRepository studentRepresentiveRepository;
+    @Autowired
+    private StudentRepository studentRepository;
+    @Autowired
+    private RepresentativeRepository representativeRepository;
+    @Autowired
+    private StudentRepresentiveRepository studentRepresentiveRepository;
 
 
     public Mono<Student> execute(Student student) {

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/DeleteStudentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/DeleteStudentUseCase.java
@@ -1,10 +1,12 @@
 package com.andersonsinaluisa.academicapi.persons.application.usecases.student;
 
 import com.andersonsinaluisa.academicapi.persons.domain.repository.StudentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 @Service
 public class DeleteStudentUseCase {
+    @Autowired
     private StudentRepository studentRepository;
     public Mono<Void> execute(Long Id){
         return studentRepository.delete(Id);

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/GetByIdStudentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/GetByIdStudentUseCase.java
@@ -2,12 +2,14 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.student;
 
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Student;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.StudentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
 public class GetByIdStudentUseCase {
 
+    @Autowired
     private StudentRepository studentRepository;
 
     public Mono<Student> execute(Long Id){

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/ListStudentByCourseIdUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/ListStudentByCourseIdUseCase.java
@@ -3,6 +3,7 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.student;
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Student;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.StudentRepository;
 import com.andersonsinaluisa.academicapi.shared.domain.FilterCriteria;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import reactor.core.publisher.Mono;
 @Service
 public class ListStudentByCourseIdUseCase {
 
+    @Autowired
     private StudentRepository studentRepository;
 
     public Mono<Page<Student>> execute(Pageable pageable, String uidParallel){

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/UpdateStudentUseCase.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/application/usecases/student/UpdateStudentUseCase.java
@@ -2,12 +2,14 @@ package com.andersonsinaluisa.academicapi.persons.application.usecases.student;
 
 import com.andersonsinaluisa.academicapi.persons.domain.entities.Student;
 import com.andersonsinaluisa.academicapi.persons.domain.repository.StudentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
 @Service
 public class UpdateStudentUseCase {
-    public StudentRepository studentRepository;
+    @Autowired
+    private StudentRepository studentRepository;
 
     public Mono<Student> execute(Long id,Student student){
         return studentRepository.update(id,student);

--- a/src/main/java/com/andersonsinaluisa/academicapi/persons/infrastructure/StudentRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/persons/infrastructure/StudentRepositoryImpl.java
@@ -6,7 +6,7 @@ import com.andersonsinaluisa.academicapi.persons.infrastructure.database.mappers
 import com.andersonsinaluisa.academicapi.persons.infrastructure.database.repository.custom.StudentCustomRepository;
 import com.andersonsinaluisa.academicapi.persons.infrastructure.database.repository.StudentPgRepository;
 import com.andersonsinaluisa.academicapi.shared.domain.FilterCriteria;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -17,10 +17,11 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
 public class StudentRepositoryImpl implements StudentRepository {
 
+    @Autowired
     private StudentPgRepository studentPgRepository;
+    @Autowired
     private StudentCustomRepository studentCustomRepository;
     @Override
     public Flux<Student> getByCourse(String courseId) {


### PR DESCRIPTION
## Summary
- add missing `@Autowired` annotations in Student and Representative controllers
- inject repositories and services with `@Autowired` across Student/Representative use cases
- ensure StudentRepositoryImpl wires dependencies via `@Autowired`
- make student use case repository fields private for proper wiring

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68be4864ba8083308c1c9ff754c4d78c