### PR TITLE
Persist teacher assignments in the database

### DIFF
--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/enrollment/TeacherAssignmentTable.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/entities/enrollment/TeacherAssignmentTable.java
@@ -4,6 +4,8 @@ import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
+import java.time.LocalDateTime;
+
 @Table(name="teacher_assignment")
 @Builder
 @Getter
@@ -16,6 +18,7 @@ public class TeacherAssignmentTable {
     public Long teacherId;
     public String subjectId;
     public String courseId;
-    public String academicYearId;
+    public Long academicYearId;
+    public LocalDateTime createdAt;
 }
 

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/mappers/TeacherAssignmentTableMapper.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/mappers/TeacherAssignmentTableMapper.java
@@ -1,0 +1,53 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.mappers;
+
+import com.andersonsinaluisa.academicapi.academic.domain.entities.teacher.TeacherAssignment;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment.TeacherAssignmentTable;
+
+public final class TeacherAssignmentTableMapper {
+
+    private TeacherAssignmentTableMapper() {
+    }
+
+    public static TeacherAssignment fromPersistenceToDomain(TeacherAssignmentTable table) {
+        if (table == null) {
+            return null;
+        }
+        return TeacherAssignment.builder()
+                .id(table.id)
+                .teacherId(table.teacherId)
+                .courseId(parseLong(table.courseId))
+                .subjectId(parseLong(table.subjectId))
+                .schoolYearId(table.academicYearId)
+                .createdAt(table.createdAt)
+                .build();
+    }
+
+    public static TeacherAssignmentTable fromDomainToPersistence(TeacherAssignment assignment) {
+        if (assignment == null) {
+            return null;
+        }
+        return TeacherAssignmentTable.builder()
+                .id(assignment.id)
+                .teacherId(assignment.teacherId)
+                .courseId(toString(assignment.courseId))
+                .subjectId(toString(assignment.subjectId))
+                .academicYearId(assignment.schoolYearId)
+                .createdAt(assignment.createdAt)
+                .build();
+    }
+
+    private static String toString(Long value) {
+        return value != null ? value.toString() : null;
+    }
+
+    private static Long parseLong(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.valueOf(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/custom/TeacherAssignmentCustomRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/custom/TeacherAssignmentCustomRepository.java
@@ -1,0 +1,64 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.custom;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment.TeacherAssignmentTable;
+import com.andersonsinaluisa.academicapi.shared.domain.FilterCriteria;
+import org.springframework.r2dbc.core.DatabaseClient;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+
+@Repository
+public class TeacherAssignmentCustomRepository {
+
+    private final DatabaseClient client;
+
+    public TeacherAssignmentCustomRepository(DatabaseClient client) {
+        this.client = client;
+    }
+
+    public Flux<TeacherAssignmentTable> findAllWithFilters(FilterCriteria filters, int limit, int offset) {
+        StringBuilder sql = new StringBuilder("SELECT * FROM teacher_assignment WHERE 1=1");
+        filters.asMap().forEach((key, value) -> {
+            if (value == null) {
+                sql.append(" AND ").append(key).append(" IS NULL");
+            } else {
+                sql.append(" AND ").append(key)
+                        .append(" = '").append(value.replace("'", "''")).append("'");
+            }
+        });
+        sql.append(" ORDER BY created_at DESC NULLS LAST, id DESC");
+        sql.append(" LIMIT ").append(limit).append(" OFFSET ").append(offset);
+
+        return client.sql(sql.toString())
+                .map((row, meta) -> TeacherAssignmentTable.builder()
+                        .id(row.get("id", Long.class))
+                        .teacherId(row.get("teacher_id", Long.class))
+                        .courseId(row.get("course_id", String.class))
+                        .subjectId(row.get("subject_id", String.class))
+                        .academicYearId(row.get("academic_year_id", Long.class))
+                        .createdAt(row.get("created_at", LocalDateTime.class))
+                        .build())
+                .all();
+    }
+
+    public Mono<Long> countWithFilters(FilterCriteria filters) {
+        StringBuilder sql = new StringBuilder("SELECT COUNT(*)::bigint as total FROM teacher_assignment WHERE 1=1");
+        filters.asMap().forEach((key, value) -> {
+            if (value == null) {
+                sql.append(" AND ").append(key).append(" IS NULL");
+            } else {
+                sql.append(" AND ").append(key)
+                        .append(" = '").append(value.replace("'", "''")).append("'");
+            }
+        });
+
+        return client.sql(sql.toString())
+                .map((row, meta) -> {
+                    Object total = row.get("total");
+                    return (total instanceof Number) ? ((Number) total).longValue() : 0L;
+                })
+                .one();
+    }
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/TeacherAssignmentPgRepository.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/database/repository/jpa/TeacherAssignmentPgRepository.java
@@ -1,0 +1,13 @@
+package com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa;
+
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment.TeacherAssignmentTable;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+@Repository
+public interface TeacherAssignmentPgRepository extends ReactiveCrudRepository<TeacherAssignmentTable, Long> {
+    Flux<TeacherAssignmentTable> findAllByTeacherId(Long teacherId);
+
+    Flux<TeacherAssignmentTable> findAllByTeacherIdAndCourseId(Long teacherId, String courseId);
+}

--- a/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/teacher/TeacherAssignmentRepositoryImpl.java
+++ b/src/main/java/com/andersonsinaluisa/academicapi/academic/infrastructure/teacher/TeacherAssignmentRepositoryImpl.java
@@ -2,51 +2,78 @@ package com.andersonsinaluisa.academicapi.academic.infrastructure.teacher;
 
 import com.andersonsinaluisa.academicapi.academic.domain.entities.teacher.TeacherAssignment;
 import com.andersonsinaluisa.academicapi.academic.domain.repository.TeacherAssignmentRepository;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.entities.enrollment.TeacherAssignmentTable;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.mappers.TeacherAssignmentTableMapper;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.custom.TeacherAssignmentCustomRepository;
+import com.andersonsinaluisa.academicapi.academic.infrastructure.database.repository.jpa.TeacherAssignmentPgRepository;
 import com.andersonsinaluisa.academicapi.shared.domain.FilterCriteria;
 import com.andersonsinaluisa.academicapi.shared.domain.PageResult;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.List;
 
-/**
- * In-memory implementation used for prototyping.
- */
 @Service
+@RequiredArgsConstructor
 public class TeacherAssignmentRepositoryImpl implements TeacherAssignmentRepository {
 
-    private final Map<Long, TeacherAssignment> store = new ConcurrentHashMap<>();
-    private final AtomicLong sequence = new AtomicLong(1);
+    private final TeacherAssignmentPgRepository repository;
+    private final TeacherAssignmentCustomRepository customRepository;
 
     @Override
     public Mono<TeacherAssignment> save(TeacherAssignment assignment) {
-        if (assignment.id == null) {
-            assignment.id = sequence.getAndIncrement();
+        if (assignment.createdAt == null) {
             assignment.createdAt = LocalDateTime.now();
         }
-        store.put(assignment.id, assignment);
-        return Mono.just(assignment);
+        TeacherAssignmentTable table = TeacherAssignmentTableMapper.fromDomainToPersistence(assignment);
+        return repository.save(table)
+                .map(TeacherAssignmentTableMapper::fromPersistenceToDomain)
+                .map(saved -> {
+                    if (saved.createdAt == null) {
+                        saved.createdAt = assignment.createdAt;
+                    }
+                    return saved;
+                });
     }
 
     @Override
     public Mono<TeacherAssignment> findById(Long id) {
-        return Mono.justOrEmpty(store.get(id));
+        return repository.findById(id)
+                .map(TeacherAssignmentTableMapper::fromPersistenceToDomain);
     }
 
     @Override
     public Flux<TeacherAssignment> findByTeacherIdAndCourseId(Long teacherId, Long courseId) {
-        return Flux.fromStream(store.values().stream()
-                .filter(a -> (teacherId == null || teacherId.equals(a.teacherId))
-                        && (courseId == null || courseId.equals(a.courseId))));
+        Flux<TeacherAssignmentTable> results = courseId == null
+                ? repository.findAllByTeacherId(teacherId)
+                : repository.findAllByTeacherIdAndCourseId(teacherId, String.valueOf(courseId));
+
+        return results.map(TeacherAssignmentTableMapper::fromPersistenceToDomain);
     }
 
     @Override
     public Mono<PageResult<TeacherAssignment>> findAll(Pageable pageable, FilterCriteria filters) {
-        return null;
+        int pageNumber = pageable.getPageNumber() <= 0 ? 0 : pageable.getPageNumber() - 1;
+        int pageSize = pageable.getPageSize();
+        int offset = pageNumber * pageSize;
+
+        Mono<List<TeacherAssignment>> content = customRepository
+                .findAllWithFilters(filters, pageSize, offset)
+                .map(TeacherAssignmentTableMapper::fromPersistenceToDomain)
+                .collectList();
+
+        Mono<Long> count = customRepository.countWithFilters(filters);
+
+        return Mono.zip(content, count)
+                .map(tuple -> {
+                    List<TeacherAssignment> assignments = tuple.getT1();
+                    long total = tuple.getT2();
+                    long totalPages = pageSize == 0 ? 0 : (long) Math.ceil((double) total / pageSize);
+                    return new PageResult<>(assignments, total, pageNumber, pageSize, totalPages);
+                });
     }
 }

--- a/src/main/resources/db/changelog/generated.sql
+++ b/src/main/resources/db/changelog/generated.sql
@@ -186,7 +186,8 @@ CREATE TABLE teacher_assignment (
     teacher_id BIGINT REFERENCES teacher(id),
     subject_id VARCHAR REFERENCES subject(id),
     course_id VARCHAR,
-    academic_year_id BIGINT REFERENCES academic_year(id)
+    academic_year_id BIGINT REFERENCES academic_year(id),
+    created_at TIMESTAMP
 );
 
 CREATE TABLE disciplinary_action (


### PR DESCRIPTION
## Summary
- replace the in-memory teacher assignment repository with a reactive implementation backed by PostgreSQL
- add mapper and custom R2DBC queries to page teacher assignments and expose finders by teacher and course
- extend the teacher_assignment table schema with creation timestamps to keep domain data in sync

## Testing
- mvn -q -DskipTests compile *(fails: TeacherAssignmentController references undefined headerTeacherId)*

------
https://chatgpt.com/codex/tasks/task_e_68deed44c9288330ad49f8f0362a2a99